### PR TITLE
README: Use the service brew provides, don't hardcode icecream versions and update to 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 All the files/scripts below can be found in this repository.
 
-At time of writing, brew installs llvm/clang 7.0 (clang version 7.0.0 (tags/RELEASE_700/final))
+At time of writing, brew installs llvm/clang 8.0 (clang version 8.0.0 (tags/RELEASE_800/final))
 
 ## Make sure you are running the latest version of icecream
 
-Ubuntu prior 18.04 shipped an old icecream version released in 2013: version 1.0.1. Upgrade to a Ubuntu 18.04 or you will find the latest release (1.1) packages for ubuntu/debian in the packages directory.
+Ubuntu prior to 18.04 shipped an old icecream version released in 2013: version 1.0.1. Upgrade to Ubuntu 18.04 or you will find the latest release (1.1) packages for ubuntu/debian in the packages directory.
 
 ## Getting icecream installed and running on Mac
 
@@ -14,45 +14,42 @@ Ubuntu prior 18.04 shipped an old icecream version released in 2013: version 1.0
 $ brew install icecream
 ```
 
-start iceccd manually with:
+start iceccd with:
 ```bash
-$ sudo /usr/local/sbin/iceccd -d -s HOSTNAME
+$ brew services start icecream
 ```
 
-Replace HOSTNAME with the hostname the icecc scheduler is running on.
+You can set the scheduler to use if auto-discovery doesn't work:
+```bash
+$ $EDITOR ~/Library/LaunchAgents/homebrew.mxcl.icecream.plist
+```
 
-Alternatively, to get the icecream iceccd daemon running at boot time
-copy the file
+In that file replace HOSTNAME_SCHEDULER with the [hostname the icecc scheduler is running on](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Using_Icecream#Running_a_scheduler).
+
 ```
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>Icecc Daemon</string>
+    <string>homebrew.mxcl.icecream</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/Cellar/icecream/1.1/sbin/iceccd</string>
+        <string>/usr/local/opt/icecream/sbin/iceccd</string>
         <string>-s</string>
         <string>HOSTNAME_SCHEDULER</string>
     </array>
-    <key>KeepAlive</key>
+    <key>RunAtLoad</key>
     <true/>
-    <key>UserName</key>
-    <string>root</string>
 </dict>
 </plist>
 ```
 
-into /Library/LaunchDaemons/com.mozilla.iceccd.plist
-There too, replace HOSTNAME with the hostname the icecc scheduler is running on.
-
-then run:
 ```bash
-$ sudo launchctl load /Library/LaunchDaemons/com.mozilla.iceccd.plist
+$ brew services restart icecream
 ```
 
-## Getting llvm-7.0 installed and running on Mac
+## Getting llvm installed and running on Mac
 
 ```bash
 $ brew install llvm
@@ -60,7 +57,7 @@ $ brew install llvm
 
 ## Getting toolchain packaged for icecream
 
-You can directly download the archives here and skip the section below.
+You can directly download the archives here and skip the rest of this section.
 https://github.com/jyavenard/mozilla-icecream/raw/master/clang-7.0.0-Darwin17_x86_64.tar.gz
 and:
 https://github.com/jyavenard/mozilla-icecream/raw/master/clang-7.0.0-x86_64.tar.gz
@@ -68,9 +65,9 @@ https://github.com/jyavenard/mozilla-icecream/raw/master/clang-7.0.0-x86_64.tar.
 
 Get the latest mac clang build at http://releases.llvm.org/download.html
 
-Current it’s 7.0.0 available at:
-mac: http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
-linux 64 bits: http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+Current it’s 8.0.0 available at:
+mac: https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-apple-darwin.tar.xz
+linux 64 bits: https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 (tested with ubuntu 18.04 only)
 
 In the following instructions, I placed everything into ~/clang for ease of documentation, you can of course place it in any location.
@@ -83,13 +80,13 @@ $ cd ~/clang
 
 Extract the archive and create the icecream toolchain archive
 ```bash
-$ wget http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
-$ tar xvf clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
-$ /usr/local/Cellar/icecream/1.1/libexec/icecc/icecc-create-env --clang ~/clang/clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang /usr/local/Cellar/icecream/1.1/libexec/icecc/compilerwrapper
+$ wget https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-apple-darwin.tar.xz
+$ tar xvf clang+llvm-8.0.0-x86_64-apple-darwin.tar.xz
+$ /usr/local/bin/icecc-create-env --clang ~/clang/clang+llvm-8.0.0-x86_64-apple-darwin/bin/clang /usr/local/Cellar/icecream/1.2_1/libexec/icecc/compilerwrapper
 ```
 
 this will create a file such ce3126a6676d8b9cd58ea709615bee97.tar.gz
-rename it into clang-7.0.0-Darwin17_x86_64.tar.gz
+rename it into clang-8.0.0-Darwin17_x86_64.tar.gz
 
 ### On Linux
 ```bash
@@ -99,52 +96,12 @@ $ cd ~/clang
 
 Extract the archive and create the icecream toolchain archive
 ```bash
-$ wget http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-$ tar xvf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-$ /usr/lib/icecc/icecc-create-env --clang ~/clang/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/clang /usr/lib/icecc/compilerwrapper
+$ wget https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+$ tar xvf clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+$ /usr/lib/icecc/icecc-create-env --clang ~/clang/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/clang /usr/lib/icecc/compilerwrapper
 ```
 
-import the generated tar.gz into your mac and rename it as clang-7.0.0-x86_64.tar.gz, place it into ~/clang
-
-## Prepare your central tree (for central 58 and earlier)
-
-If you want to compile central version 58 and earlier, you need to need to apply the following patches:
-
-```
-diff --git a/media/ffvpx/ffvpxcommon.mozbuild b/media/ffvpx/ffvpxcommon.mozbuild
-index fdca987f49ef..4577d1440b9d 100644
---- a/media/ffvpx/ffvpxcommon.mozbuild
-+++ b/media/ffvpx/ffvpxcommon.mozbuild
-@@ -66,6 +66,7 @@ if CONFIG['GNU_CC']:
-             '-Wno-incompatible-pointer-types-discards-qualifiers',
-             '-Wno-string-conversion',
-             '-Wno-visibility',
-+            '-ffreestanding',
-         ]
-     else:
-         CFLAGS += [
-diff --git a/old-configure.in b/old-configure.in
-index 849146516063..f99ceb3a16cd 100644
---- a/old-configure.in
-+++ b/old-configure.in
-@@ -4790,10 +4790,10 @@ AC_SUBST(MOZ_SYSTEM_NSPR)
- 
- AC_SUBST(MOZ_SYSTEM_NSS)
- 
--HOST_CMFLAGS=-fobjc-exceptions
--HOST_CMMFLAGS=-fobjc-exceptions
--OS_COMPILE_CMFLAGS=-fobjc-exceptions
--OS_COMPILE_CMMFLAGS=-fobjc-exceptions
-+HOST_CMFLAGS="-x objective-c -fobjc-exceptions"
-+HOST_CMMFLAGS="-x objective-c++ -fobjc-exceptions"
-+OS_COMPILE_CMFLAGS="-x objective-c -fobjc-exceptions"
-+OS_COMPILE_CMMFLAGS="-x objective-c++ -fobjc-exceptions"
- if test "$MOZ_WIDGET_TOOLKIT" = uikit; then
-   OS_COMPILE_CMFLAGS="$OS_COMPILE_CMFLAGS -fobjc-abi-version=2 -fobjc-legacy-dispatch"
-   OS_COMPILE_CMMFLAGS="$OS_COMPILE_CMMFLAGS -fobjc-abi-version=2 -fobjc-legacy-dispatch"
-```
-
-As of central 2017-11-28 you no longer need to modify old-configure.in
+import the generated tar.gz into your mac and rename it as clang-8.0.0-x86_64.tar.gz, place it into ~/clang
 
 ## Configure your mozbuild for using icecream
 
@@ -179,12 +136,12 @@ ac_add_options --enable-ffmpeg
 #mk_add_options 'export RUSTC_WRAPPER=sccache'
 mk_add_options 'export CARGO_INCREMENTAL=1'
 
-mk_add_options "export ICECC_VERSION=x86_64:$HOME/clang/clang-7.0.0-x86_64.tar.gz,Darwin17_x86_64:$HOME/clang/clang-7.0.0-Darwin17_x86_64.tar.gz"
+mk_add_options "export ICECC_VERSION=x86_64:$HOME/clang/clang-8.0.0-x86_64.tar.gz,Darwin17_x86_64:$HOME/clang/clang-8.0.0-Darwin17_x86_64.tar.gz"
 mk_add_options "export ICECC_CC=/usr/local/opt/llvm/bin/clang"
 mk_add_options "export ICECC_CXX=/usr/local/opt/llvm/bin/clang++"
 
-CC="/usr/local/Cellar/icecream/1.1/libexec/icecc/bin/clang --target=x86_64-apple-darwin16.0.0 -mmacosx-version-min=10.11"
-CXX="/usr/local/Cellar/icecream/1.1/libexec/icecc/bin/clang++ --target=x86_64-apple-darwin16.0.0 -mmacosx-version-min=10.11"
+CC="/usr/local/opt/icecream/libexec/icecc/bin/clang --target=x86_64-apple-darwin16.0.0 -mmacosx-version-min=10.11"
+CXX="/usr/local/opt/icecream/libexec/icecc/bin/clang++ --target=x86_64-apple-darwin16.0.0 -mmacosx-version-min=10.11"
 ```
 
 ### On Linux
@@ -210,7 +167,7 @@ ac_add_options --disable-optimize
 #mk_add_options 'export RUSTC_WRAPPER=sccache'
 mk_add_options 'export CARGO_INCREMENTAL=1'
 
-mk_add_options "export ICECC_VERSION=x86_64:$HOME/clang/clang-7.0.0-x86_64.tar.gz"
+mk_add_options "export ICECC_VERSION=x86_64:$HOME/clang/clang-8.0.0-x86_64.tar.gz"
 mk_add_options "export ICECC_CC=/usr/bin/clang-6.0"
 mk_add_options "export ICECC_CXX=/usr/bin/clang++-6.0"
 
@@ -222,7 +179,7 @@ CXX="/usr/lib/icecc/bin/clang++ --target=x86_64-pc-linux-gnu"
 
 You may find that only using the remote linux host makes your compilation much quicker, to do so, remove the Darwin17_x86_64 entry from ICECC_VERSION:
 ```bash
-ICECC_VERSION="x86_64:$HOME/clang/clang-7.0.0-x86_64.tar.gz" ./mach build -j32
+ICECC_VERSION="x86_64:$HOME/clang/clang-8.0.0-x86_64.tar.gz" ./mach build -j32
 ```
 
 A note of caution, the paths in ICECC_VERSION can't be symbolic links.


### PR DESCRIPTION
I also [built 8.0.0 binaries](https://github.com/mnoorenberghe/mozilla-icecream/commit/0a9d66c8c5a8e124c2ca4c254b15f4297d210b95) to fix #3 but didn't include them in the PR since they emit warnings about library version mismatches… perhaps because I created the Linux one on Fedora? The warnings seem to be harmless though.